### PR TITLE
Fix sort order selector when default order is not included on the page

### DIFF
--- a/templates/catalog/_partials/sort-orders.tpl
+++ b/templates/catalog/_partials/sort-orders.tpl
@@ -22,18 +22,11 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
-{assign var="includeEmptySort" value="1"}
-{foreach from=$listing.sort_orders item=sort_order}
-    {if $sort_order.current == '1'}
-        {assign var="includeEmptySort" value="0"}
-    {/if}
-{/foreach}
-
 <div class="form-inline">
     <div class="form-group mb-0">
         <label for="select-sort-order" class="visible--desktop">{l s='Sort by:' d='Shop.Theme.Global'}</label>
         <select class="custom-select ml-sm-2" id="select-sort-order">
-            {if $includeEmptySort == '1'}
+            {if !$listing.sort_selected}
                 <option selected="selected">--</option>
             {/if}
             {foreach from=$listing.sort_orders item=sort_order}

--- a/templates/catalog/_partials/sort-orders.tpl
+++ b/templates/catalog/_partials/sort-orders.tpl
@@ -22,10 +22,20 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
+{assign var="includeEmptySort" value="1"}
+{foreach from=$listing.sort_orders item=sort_order}
+    {if $sort_order.current == '1'}
+        {assign var="includeEmptySort" value="0"}
+    {/if}
+{/foreach}
+
 <div class="form-inline">
     <div class="form-group mb-0">
         <label for="select-sort-order" class="visible--desktop">{l s='Sort by:' d='Shop.Theme.Global'}</label>
         <select class="custom-select ml-sm-2" id="select-sort-order">
+            {if $includeEmptySort == '1'}
+                <option>--</option>
+            {/if}
             {foreach from=$listing.sort_orders item=sort_order}
                 <option value="{$sort_order.url}"{if $sort_order.current} selected="selected"{/if}>{$sort_order.label}</option>
             {/foreach}

--- a/templates/catalog/_partials/sort-orders.tpl
+++ b/templates/catalog/_partials/sort-orders.tpl
@@ -34,7 +34,7 @@
         <label for="select-sort-order" class="visible--desktop">{l s='Sort by:' d='Shop.Theme.Global'}</label>
         <select class="custom-select ml-sm-2" id="select-sort-order">
             {if $includeEmptySort == '1'}
-                <option>--</option>
+                <option selected="selected">--</option>
             {/if}
             {foreach from=$listing.sort_orders item=sort_order}
                 <option value="{$sort_order.url}"{if $sort_order.current} selected="selected"{/if}>{$sort_order.label}</option>


### PR DESCRIPTION
This PR fixes a bug, when there is a different sort order selected on initial load than the one currently in use.

**How to reproduce the bug**
1. Go to Prestashop settins and set default sorting in category to "quantity".
2. Enable and setup faceted search.
3. Go to FO to some category.
4. You will see that products are sorted by quantity, but there is Relevance/Position selected in a selectbox.