### PR TITLE
hide arrows/spinners in quantity input touchspin

### DIFF
--- a/_dev/css/partials/_commons.scss
+++ b/_dev/css/partials/_commons.scss
@@ -86,6 +86,12 @@ h1,.h1{
     box-shadow: none;
     text-align: center;
     font-weight: 700;
+    
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0; 
+    }
   }
   .btn {
     position: relative;


### PR DESCRIPTION
this is a css fix to correct the number in quantity input to be centered in middle.