### PR TITLE
issue in product-comments-list.tpl with quotes

### DIFF
--- a/modules/productcomments/views/templates/hook/product-comments-list.tpl
+++ b/modules/productcomments/views/templates/hook/product-comments-list.tpl
@@ -24,8 +24,8 @@
  *}
 
 <script type="text/javascript">
-  var productCommentUpdatePostErrorMessage = '{l s='Sorry, your review appreciation cannot be sent.' d='Modules.Productcomments.Shop' js=1}';
-  var productCommentAbuseReportErrorMessage = '{l s='Sorry, your abuse report cannot be sent.' d='Modules.Productcomments.Shop' js=1}';
+  var productCommentUpdatePostErrorMessage = `{l s='Sorry, your review appreciation cannot be sent.' d='Modules.Productcomments.Shop' js=1}`;
+  var productCommentAbuseReportErrorMessage = `{l s='Sorry, your abuse report cannot be sent.' d='Modules.Productcomments.Shop' js=1}`;
 </script>
 <div class="product-comments">
 <div class="comments__header" id="product-comments-list-header">


### PR DESCRIPTION
If the translation has simple quote like in french, create a syntax error : 
![image](https://user-images.githubusercontent.com/15829643/97306345-a6d68080-185e-11eb-874a-69b33e807000.png)

resolved : 
![image](https://user-images.githubusercontent.com/15829643/97306388-b655c980-185e-11eb-8308-c28a23e20ef5.png)
