### PR TITLE
Fix duplicated hook data after product page refresh

### DIFF
--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -115,5 +115,5 @@
       </div>
       {/if}
   {/block}
-</div>
 {hook h='displayAfterProductThumbs'}
+</div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | https://github.com/PrestaShop/PrestaShop/issues/22113
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22113
| How to test?  | Make a module that hooks to displayAfterProductThumbs. Add something to cart or change combination. The data will be duplicated.