### PR TITLE
Fix regex for jpeg and jpg, fixes #212

### DIFF
--- a/_dev/webpack.config.js
+++ b/_dev/webpack.config.js
@@ -100,7 +100,7 @@ module.exports = (env, argv) => {
                     }
                 },
                 {
-                    test: /\.(png|jp(e)g|gif|svg|webp)$/,
+                    test: /\.(png|jpe?g|gif|svg|webp)$/,
                     use: [
                         {
                             loader: 'file-loader',


### PR DESCRIPTION
Even tho there are no jpeg or jpg files child themes might want to use the same configuration and it does not cost anything to add these.