### PR TITLE
Fix translate javascript

### DIFF
--- a/modules/productcomments/views/templates/hook/post-comment-modal.tpl
+++ b/modules/productcomments/views/templates/hook/post-comment-modal.tpl
@@ -24,7 +24,7 @@
  *}
 
 <script type="text/javascript">
-    var productCommentPostErrorMessage = '{l s='Sorry, your review cannot be posted.' d='Modules.Productcomments.Shop' js=1}';
+    var productCommentPostErrorMessage = '{l|escape:'javascript' s='Sorry, your review cannot be posted.' d='Modules.Productcomments.Shop'}';
 </script>
 
 <div id="post-product-comment-modal" class="modal fade product-comment-modal" role="dialog" aria-hidden="true">

--- a/modules/productcomments/views/templates/hook/product-comments-list.tpl
+++ b/modules/productcomments/views/templates/hook/product-comments-list.tpl
@@ -24,8 +24,8 @@
  *}
 
 <script type="text/javascript">
-  var productCommentUpdatePostErrorMessage = '{l s='Sorry, your review appreciation cannot be sent.' d='Modules.Productcomments.Shop' js=1}';
-  var productCommentAbuseReportErrorMessage = '{l s='Sorry, your abuse report cannot be sent.' d='Modules.Productcomments.Shop' js=1}';
+  var productCommentUpdatePostErrorMessage = '{l|escape:'javascript' s='Sorry, your review appreciation cannot be sent.' d='Modules.Productcomments.Shop'}';
+  var productCommentAbuseReportErrorMessage = '{l|escape:'javascript' s='Sorry, your abuse report cannot be sent.' d='Modules.Productcomments.Shop'}';
 </script>
 <div class="product-comments">
 <div class="comments__header" id="product-comments-list-header">


### PR DESCRIPTION
Fixes #235 
In the template for the productcomments module, the translated javascript variables are incorrectly escaped.
This leads to an error if the translation contains an apostrophe.