### PR TITLE
Class thumbnail-container is required for blockwishlist.

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -24,7 +24,7 @@
  *}
 {block name='product_miniature_item'}
     <article class="product-miniature js-product-miniature mb-3" data-id-product="{$product.id_product}" data-id-product-attribute="{$product.id_product_attribute}">
-        <div class="card card-product">
+        <div class="card card-product thumbnail-container">
 
             <div class="card-img-top product__card-img">
                 {block name='product_thumbnail'}


### PR DESCRIPTION
Fixes #236 
Blockwishlist module requires a class="thumbnail-container" in the product miniature template.
The wishlist buttons are not displayed and a javascript error is thrown.