### PR TITLE
Default format for product details.

### DIFF
--- a/_dev/css/components/products.scss
+++ b/_dev/css/components/products.scss
@@ -361,7 +361,7 @@
 
 .products-selection{
   justify-content: space-between;
-  align-items: center; 
+  align-items: center;
 }
 .pack-miniature-item{
   margin-bottom: $spacer / 2;
@@ -450,4 +450,23 @@
 }
 .nav-tabs{
   justify-content: center;
+}
+#product-details {
+  > div > label, dt {
+    font-weight: 500;
+    min-width: 6em;
+  }
+  .h6 {
+    font-weight: bold;
+  }
+  dt {
+    display: inline-block;
+  }
+  dd {
+    display: inline;
+    &::after{
+      display: block;
+      content: '';
+    }
+  }
 }


### PR DESCRIPTION
On the product page, the product detail tab has no associated styles.
I propose here a default styling. I hope they are acceptable. If they are not according to one of your guideline, please advice.
I might add other missing default styling later.