### PR TITLE
Show product variants only if it has content

### DIFF
--- a/templates/catalog/_partials/product-variants.tpl
+++ b/templates/catalog/_partials/product-variants.tpl
@@ -22,47 +22,49 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
-<div class="product-variants">
-  {foreach from=$groups key=id_attribute_group item=group}
-      {if !empty($group.attributes)}
-      <div class="form-group product-variants-item">
-      {if $group.group_type == 'select'}
-          <label for="group_{$id_attribute_group}">{$group.name}</label>
-          <div>
-          <select
-          class="custom-select w-auto"
-          id="group_{$id_attribute_group}"
-          data-product-attribute="{$id_attribute_group}"
-          name="group[{$id_attribute_group}]">
-          {foreach from=$group.attributes key=id_attribute item=group_attribute}
-            <option value="{$id_attribute}" title="{$group_attribute.name}"{if $group_attribute.selected} selected="selected"{/if}>{$group_attribute.name}</option>
-          {/foreach}
-        </select>
-          </div>
-      {elseif $group.group_type == 'color'}
-          <div class="label">{$group.name}</div>
-          <div class="clearfix">
-          {foreach from=$group.attributes key=id_attribute item=group_attribute}
-              <label class="label-color">
-                <input class="input-color d--none" type="radio" data-product-attribute="{$id_attribute_group}" name="group[{$id_attribute_group}]" value="{$id_attribute}"{if $group_attribute.selected} checked="checked"{/if}>
-                <span
-                  {if $group_attribute.html_color_code && !$group_attribute.texture}class="color" style="background-color: {$group_attribute.html_color_code}" {/if}
-                  {if $group_attribute.texture}class="color texture" style="background-image: url({$group_attribute.texture})" {/if}
-                ><span class="sr-only">{$group_attribute.name}</span></span>
-              </label>
-          {/foreach}
-          </div>
+{if !empty($groups)}
+  <div class="product-variants">
+    {foreach from=$groups key=id_attribute_group item=group}
+        {if !empty($group.attributes)}
+        <div class="form-group product-variants-item">
+        {if $group.group_type == 'select'}
+            <label for="group_{$id_attribute_group}">{$group.name}</label>
+            <div>
+            <select
+            class="custom-select w-auto"
+            id="group_{$id_attribute_group}"
+            data-product-attribute="{$id_attribute_group}"
+            name="group[{$id_attribute_group}]">
+            {foreach from=$group.attributes key=id_attribute item=group_attribute}
+              <option value="{$id_attribute}" title="{$group_attribute.name}"{if $group_attribute.selected} selected="selected"{/if}>{$group_attribute.name}</option>
+            {/foreach}
+          </select>
+            </div>
+        {elseif $group.group_type == 'color'}
+            <div class="label">{$group.name}</div>
+            <div class="clearfix">
+            {foreach from=$group.attributes key=id_attribute item=group_attribute}
+                <label class="label-color">
+                  <input class="input-color d--none" type="radio" data-product-attribute="{$id_attribute_group}" name="group[{$id_attribute_group}]" value="{$id_attribute}"{if $group_attribute.selected} checked="checked"{/if}>
+                  <span
+                    {if $group_attribute.html_color_code && !$group_attribute.texture}class="color" style="background-color: {$group_attribute.html_color_code}" {/if}
+                    {if $group_attribute.texture}class="color texture" style="background-image: url({$group_attribute.texture})" {/if}
+                  ><span class="sr-only">{$group_attribute.name}</span></span>
+                </label>
+            {/foreach}
+            </div>
 
-      {elseif $group.group_type == 'radio'}
-          <div class="label">{$group.name}</div>
-          {foreach from=$group.attributes key=id_attribute item=group_attribute}
-              <div class="custom-control custom-radio">
-                <input id="r-variant-{$id_attribute_group}-{$id_attribute}" class="custom-control-input" type="radio" data-product-attribute="{$id_attribute_group}" name="group[{$id_attribute_group}]" value="{$id_attribute}"{if $group_attribute.selected} checked="checked"{/if}>
-                <label class="custom-control-label" for="r-variant-{$id_attribute_group}-{$id_attribute}">{$group_attribute.name}</label>
-              </div>
-          {/foreach}
+        {elseif $group.group_type == 'radio'}
+            <div class="label">{$group.name}</div>
+            {foreach from=$group.attributes key=id_attribute item=group_attribute}
+                <div class="custom-control custom-radio">
+                  <input id="r-variant-{$id_attribute_group}-{$id_attribute}" class="custom-control-input" type="radio" data-product-attribute="{$id_attribute_group}" name="group[{$id_attribute_group}]" value="{$id_attribute}"{if $group_attribute.selected} checked="checked"{/if}>
+                  <label class="custom-control-label" for="r-variant-{$id_attribute_group}-{$id_attribute}">{$group_attribute.name}</label>
+                </div>
+            {/foreach}
+        {/if}
+      </div>
       {/if}
-    </div>
-    {/if}
-  {/foreach}
-</div>
+    {/foreach}
+  </div>
+{/if}


### PR DESCRIPTION
If the product doesn't have variants, the .product-variants div is still shown. This causes problems when styling the .product-variants div with background colors or padding.

Only show the .product-variants div if it has content.