### PR TITLE
Do not display zoom button in quickview.

### DIFF
--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -76,7 +76,7 @@
           {/if}
       {/foreach}
   </div>
-      {if $product.default_image}
+      {if $product.default_image && !isset($quickview)}
       <button type="button" class="btn btn-link btn-zoom visible-desktop product-layer-zoom" data-toggle="modal" data-target="#product-modal">
           <i class="material-icons zoom-in">&#xE8FF;</i>
       </button>

--- a/templates/catalog/_partials/quickview.tpl
+++ b/templates/catalog/_partials/quickview.tpl
@@ -35,7 +35,7 @@
       <div class="row">
         <div class="col col-sm-6 visible--desktop">
           {block name='product_cover_thumbnails'}
-            {include file='catalog/_partials/product-cover-thumbnails.tpl'}
+            {include file='catalog/_partials/product-cover-thumbnails.tpl' quickview=true}
           {/block}
         </div>
         <div class="col col-sm-6">


### PR DESCRIPTION
The preview of an article (`quickview.tpl`) diplays a zoom button without functionality.

This PR removes this redundant button.