### PR TITLE
Fix: changing the country creates a new address

### DIFF
--- a/templates/checkout/_partials/address-form.tpl
+++ b/templates/checkout/_partials/address-form.tpl
@@ -13,7 +13,7 @@
       method="POST"
       action="{url entity='order' params=['id_address' => $id_address]}"
       data-id-address="{$id_address}"
-      data-refresh-url="{url entity='order' params=['ajax' => 1, 'action' => 'addressForm']}"
+      data-refresh-url="{url entity='order' params=['ajax' => 1, 'action' => 'addressForm', 'id_address' => $id_address]}"
       class="needs-validation"
       novalidate
     >

--- a/templates/checkout/_partials/steps/addresses.tpl
+++ b/templates/checkout/_partials/steps/addresses.tpl
@@ -29,7 +29,7 @@
     <form
       method="POST"
       action="{url entity='order' params=['id_address' => $id_address]}"
-      data-refresh-url="{url entity='order' params=['ajax' => 1, 'action' => 'addressForm']}"
+      data-refresh-url="{url entity='order' params=['ajax' => 1, 'action' => 'addressForm', 'id_address' => $id_address]}"
       {if $show_delivery_address_form || ($show_invoice_address_form && !$use_same_address)}class="needs-validation" autocomplete="false" novalidate{/if}
     >
       {if !$use_same_address}

--- a/templates/customer/_partials/address-form.tpl
+++ b/templates/customer/_partials/address-form.tpl
@@ -35,7 +35,7 @@
       class="needs-validation"
       action="{url entity='address' params=['id_address' => $id_address]}"
       data-id-address="{$id_address}"
-      data-refresh-url="{url entity='address' params=['ajax' => 1, 'action' => 'addressForm']}"
+      data-refresh-url="{url entity='address' params=['ajax' => 1, 'action' => 'addressForm', 'id_address' => $id_address]}"
       novalidate
       autocomplete="false"
     >


### PR DESCRIPTION
Fixes #302, see https://github.com/PrestaShop/PrestaShop/issues/30375.

When changing the country in the form, an ajax call is made, and it needs to include the `$id_address`.