### PR TITLE
Fix smarty deprecation stripslashes

### DIFF
--- a/templates/customer/password-email.tpl
+++ b/templates/customer/password-email.tpl
@@ -51,7 +51,7 @@
     <section class="form-fields">
       <div class="form-group">
         <label for="email">{l s='Email address' d='Shop.Forms.Labels'}</label>
-          <input type="email" name="email" id="email" value="{if isset($smarty.post.email)}{$smarty.post.email|stripslashes}{/if}" class="form-control" required autocomplete="email">
+          <input type="email" name="email" id="email" value="{if isset($smarty.post.email)}{stripslashes($smarty.post.email)}{/if}" class="form-control" required autocomplete="email">
           <div class="invalid-feedback js-invalid-feedback-browser"></div>
       </div>
       <button class="form-control-submit btn btn-primary" name="submit" type="submit">

--- a/templates/customer/password-new.tpl
+++ b/templates/customer/password-new.tpl
@@ -48,7 +48,7 @@
           {l
             s='Email address: %email%'
             d='Shop.Theme.Customeraccount'
-            sprintf=['%email%' => $customer_email|stripslashes]}
+            sprintf=['%email%' => stripslashes($customer_email)]}
         </div>
 
           <div class="form-group">


### PR DESCRIPTION
Since Prestashop 8.0.4 and PHP 8.0, there is a user deprecation notice about 

     User Deprecated: Using php-function "stripslashes" as a modifier is deprecated and will be removed in a future release. 
     Use Smarty::registerPlugin to explicitly register a custom modifier.

This PR is fixing it. https://github.com/PrestaShop/PrestaShop/issues/32703